### PR TITLE
Fixed incorrect argument for deserialization visitor

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -14,7 +14,6 @@
         <service id="epwt_array_jms_serializer.array_deserialization_visitor"
                  class="EPWT\ArrayJMSSerializerBundle\Visitor\ArrayDeserializationVisitor">
             <argument type="service" id="jms_serializer.naming_strategy"/>
-            <argument type="service" id="jms_serializer.object_constructor"/>
             <tag name="jms_serializer.deserialization_visitor" format="array"/>
         </service>
     </services>


### PR DESCRIPTION
JMS serializer does not using the second argument in `AbstractVisitor` constructor in versions prior to 1.6.0. However since 1.6.0 the second argument is introduced in [AbstractVisitor](https://github.com/schmittjoh/serializer/blob/1.6.0/src/JMS/Serializer/AbstractVisitor.php#L34). This PR removes incorrect argument from service definition and fixes fatal error.